### PR TITLE
プロジェクトとnlpアプリケーションのurlを結びつける

### DIFF
--- a/ai_app/urls.py
+++ b/ai_app/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path("", include("nlp.urls"))
 ]


### PR DESCRIPTION
## issue

Fixes #14 

## 目的とやったこと

Djangoプロジェクト直下のurls.pyにアプリケーションのurlを設定した。
