### PR TITLE
ライブラリのバージョン指定を「=」から「==」に修正

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas
-scikit-learn=1.4.1.post1
-django=5.0.4
+scikit-learn==1.4.1.post1
+django==5.0.4
 gunicorn


### PR DESCRIPTION
## 目的とやったこと

デプロイするときに必要となるライブラリをまとめた「requirements.txt」内でバージョン指定の表記の仕方に間違いがあったため、修正を施した。